### PR TITLE
Fix Pages build: avoid compound where_exp for Jekyll 3.10

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -122,7 +122,9 @@
 
           {% assign director  = site.team | where_exp: "m", "m.category == 0" | sort: "name" %}
           {% assign postdocs  = site.team | where_exp: "m", "m.category == 5" | sort: "name" %}
-          {% assign grads     = site.team | where_exp: "m", "m.category == 1 or m.category == 2" | sort: "name" %}
+          {% assign grads1    = site.team | where_exp: "m", "m.category == 1" %}
+          {% assign grads2    = site.team | where_exp: "m", "m.category == 2" %}
+          {% assign grads     = grads1 | concat: grads2 | sort: "name" %}
           {% assign undergrad = site.team | where_exp: "m", "m.category == 4" | sort: "name" %}
           {% assign visitors  = site.team | where_exp: "m", "m.category == 3" | sort: "name" %}
           {% assign alumni    = site.team | where_exp: "m", "m.category == 8" | sort: "name" %}


### PR DESCRIPTION
## Problem
The `pages build and deployment / build (dynamic)` job failed after the redesign merge:

```
Liquid syntax error (line 125): Expected end_of_string but found id in /_layouts/default.html
```

GitHub Pages' dynamic build uses **Jekyll 3.10** (via the `github-pages` gem), whose `where_exp` filter does not support boolean operators. The graduate-researcher query used a compound condition (`m.category == 1 or m.category == 2`), which builds fine on Jekyll 4 locally but breaks on Jekyll 3.10.

## Fix
Split the compound `where_exp` into two single-condition queries combined with `concat`:

```liquid
{% assign grads1 = site.team | where_exp: "m", "m.category == 1" %}
{% assign grads2 = site.team | where_exp: "m", "m.category == 2" %}
{% assign grads  = grads1 | concat: grads2 | sort: "name" %}
```

Verified with a local **Jekyll 3.10.0** build (the Pages environment): clean build, all team sections render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa