### PR TITLE
Fix mobile width of Director and Postdoc lead cards

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -586,6 +586,7 @@ strong, b { font-weight: 600; }
   .member-card--lead .member-photo { width: 160px; margin: 0 auto; }
   .member-bio { text-align: left; }
   .team-grid { grid-template-columns: 1fr 1fr; gap: 1.4rem; }
+  .team-grid--lead { grid-template-columns: 1fr; }
   .member-card { padding: 1.4rem; }
   .alum-grid { grid-template-columns: 1fr; }
   .research-grid { gap: 1.8rem; }


### PR DESCRIPTION
## Problem
On mobile, the **Steve Drew** (Director) and **Vincent Michalski** (Postdoc) lead panels only took half the page width.

## Cause
The lead cards are wrapped in `<div class="team-grid team-grid--lead">`. The mobile rule added to make graduate cards 2-up —
`.team-grid { grid-template-columns: 1fr 1fr }` — also matched the lead container (same class), so the single lead card sat in one of two columns.

## Fix
Re-assert a single column for `.team-grid--lead` inside the `max-width: 720px` breakpoint:

```css
.team-grid--lead { grid-template-columns: 1fr; }
```

Grad cards stay 2-up; the lead panels span full width. Verified at 390px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa