### PR TITLE
Remove hero tagline

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,10 +43,6 @@
     <header class="hero">
       <div class="wrap">
         <img class="hero-logo" src="images/DenosLab.png" alt="Distributed Learning and Orchestration (DENOS) Lab, University of Calgary">
-        <p class="hero-tagline">
-          We build intelligent, sustainable, and privacy-preserving systems for
-          <strong>distributed learning, agentic simulation and reasoning</strong> across cloud-edge infrastructures.
-        </p>
         <div class="hero-cta">
           <a class="btn" href="#research">Our research</a>
           <a class="btn btn--ghost" href="#news">Join the lab</a>


### PR DESCRIPTION
Removes the "We build intelligent, sustainable, and privacy-preserving systems for distributed learning, agentic simulation and reasoning across cloud-edge infrastructures" tagline from the hero. The hero now shows the logo and the call-to-action buttons.

Note: the same sentence also appears in the About section intro; left in place there for now. Happy to remove it there too if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa