### PR TITLE
Remove Links nav menu; shorten research descriptions

### DIFF
--- a/_includes/research.html
+++ b/_includes/research.html
@@ -13,16 +13,10 @@
     <img class="research-logo" src="{{ '/images/edsim.png' | relative_url }}" alt="ED Sim emergency department floor plan">
     <h3 class="research-title">Multi-Agent AI for Emergency Department Operations</h3>
     <p>
-      <strong>ED Sim</strong> is a large language model simulation that builds a full digital
-      model of an emergency department, with autonomous agents standing in for patients, nurses,
-      physicians, and other staff. Clinicians and administrators can find bottlenecks and test
-      changes in the simulation without disrupting real operations.
-    </p>
-    <p>
-      We pair the simulation with an AI tool that rapidly summarizes patient histories so that
-      clinicians spend less time on screens and more on care. Developed with Dr. Jessalyn
-      Holodinsky, the work aims to shorten wait times, improve patient care, and ease clinician
-      burnout.
+      <strong>ED Sim</strong> is a large language model simulation of an emergency department,
+      with autonomous agents for patients, nurses, and physicians. Built with Dr. Jessalyn
+      Holodinsky, it lets teams find bottlenecks and test changes without disrupting real
+      operations, aiming to cut wait times and clinician burnout.
     </p>
   </article>
 
@@ -33,18 +27,11 @@
     <img class="research-logo" src="{{ '/images/starfish-logo.png' | relative_url }}" alt="The STARFISH Project">
     <h3 class="research-title">Secure, Transactable, Agentic Health Data Sharing</h3>
     <p>
-      <strong>STARFISH</strong> is a secure and interoperable framework for global health
-      data sharing that lets individuals control their data while enabling compliant
-      research access. It introduces an agentic AI protocol for autonomous,
-      privacy-preserving data exchange between personal and institutional agents, using
-      verifiable consent, blockchain auditability, and automated compliance.
-    </p>
-    <p>
-      STARFISH formalizes permissions through cryptographically signed Consent Mandates and
-      Data Package Mandates, settles value between agents through the Agent Payments Protocol
-      (AP2), and records every transaction on a blockchain so that verification stays
-      tamper-proof across jurisdictions. Analytics run inside a secure computation container
-      so that fairness and trust hold across multi-agent interactions.
+      <strong>STARFISH</strong> is a secure, interoperable framework for global health data
+      sharing that lets individuals control their data while enabling compliant research. Its
+      agentic AI protocol exchanges data between personal and institutional agents using
+      verifiable consent, cryptographically signed mandates, the Agent Payments Protocol (AP2),
+      and blockchain auditability, with analytics run inside a secure computation container.
     </p>
   </article>
 
@@ -56,15 +43,10 @@
     <h3 class="research-title">Agentic Simulation for Wildfire Evacuations</h3>
     <p>
       <strong>AgentEvac</strong> is an agentic simulator for wildfire evacuations that couples
-      SUMO traffic simulation with LLM-driven agents. Each agent follows the Protective Action
-      Decision Model (PADM), maintaining probabilistic beliefs about hazard states and making
-      real-time departure, routing, and destination decisions under uncertainty.
-    </p>
-    <p>
-      By encoding psychologically grounded, communicative, and adaptive behavior, AgentEvac lets
-      us test warning strategies and route policies before a crisis. We compare no-notice,
-      alert-guided, and advice-guided regimes and measure how information uncertainty,
-      communication delays, and social trust shape safety and efficiency.
+      SUMO traffic simulation with LLM-driven agents following the Protective Action Decision
+      Model (PADM). By encoding psychologically grounded, adaptive behavior, it lets us test
+      warning strategies and route policies and measure how uncertainty and social trust shape
+      safety and efficiency.
     </p>
   </article>
 
@@ -76,15 +58,9 @@
     <h3 class="research-title">Role-Aware Multi-Agent Grading of Clinical Summaries</h3>
     <p>
       <strong>LENS</strong> is a role-aware multi-agent pipeline that grades clinical summaries.
-      The same summary is scored in parallel by three role-specific agents standing in for a
-      physician, a triage nurse, and a bedside nurse, each rating it across eight rubric
-      dimensions.
-    </p>
-    <p>
-      LENS then combines the role scorecards into per-role and cross-role overall scores and
-      builds an Orchestrator Disagreement view that shows where the three roles diverge on each
-      dimension. By making evaluation transparent and role-aware, it supports trustworthy
-      assessment of AI-generated clinical text.
+      Three agents standing in for a physician, a triage nurse, and a bedside nurse score each
+      summary across eight rubric dimensions, and an Orchestrator Disagreement view shows where
+      their judgments diverge.
     </p>
   </article>
 
@@ -94,17 +70,10 @@
     </div>
     <h3 class="research-title">Federated Learning for Edge Service Orchestration</h3>
     <p>
-      As <strong>federated learning (FL)</strong> is adopted across heterogeneous
-      infrastructures, performance degradation and slow convergence drive excessive energy
-      use on both cloud resources and battery-powered edge IoT devices. We design FL methods
-      that guide cloud-edge orchestration toward resilient, sustainable, real-world
-      deployment.
-    </p>
-    <p>
-      Our work budgets FL clients dynamically based on node availability and carbon
-      footprint, replicates tasks to improve robustness while limiting privacy impact, and
-      builds prototype orchestration schedulers that we evaluate in real cloud-edge
-      environments.
+      As <strong>federated learning (FL)</strong> spreads across heterogeneous infrastructures,
+      slow convergence drives excessive energy use on cloud and battery-powered edge devices. We
+      design FL methods that budget clients by availability and carbon footprint and guide
+      cloud-edge orchestration toward resilient, sustainable, real-world deployment.
     </p>
   </article>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -62,17 +62,6 @@
           <li class="navbar-item"><a class="navbar-link" href="#publications">Publications</a></li>
           <li class="navbar-item"><a class="navbar-link" href="#calendar">Calendar</a></li>
           <li class="navbar-item"><a class="navbar-link" href="https://github.com/DENOSlab/" target="_blank" rel="noopener">Software</a></li>
-          <li class="navbar-item navbar-item--right">
-            <a class="navbar-link" href="#" data-popover="#moreNavPopover">Links ▾</a>
-            <div id="moreNavPopover" class="popover">
-              <ul class="popover-list">
-                <li class="popover-item"><a class="popover-link" href="https://github.com/DENOSlab/labinfo" target="_blank" rel="noopener">Lab Docs</a></li>
-                <li class="popover-item"><a class="popover-link" href="https://github.com/DENOSlab/labinfo/tree/master/seminars" target="_blank" rel="noopener">Seminars</a></li>
-                <li class="popover-item"><a class="popover-link" href="https://scholar.google.com/citations?user=mGMBNN4AAAAJ&hl=en" target="_blank" rel="noopener">Scholar</a></li>
-                <li class="popover-item"><a class="popover-link" href="https://profiles.ucalgary.ca/steve-drew" target="_blank" rel="noopener">UCalgary</a></li>
-              </ul>
-            </div>
-          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- **Removes the Links dropdown** from the navbar (Lab Docs, Seminars, Scholar, UCalgary). The nav now ends at Software.
- **Shortens each of the five research panel descriptions** to roughly half their previous length (now ~41-54 words each, down from ~75-110), keeping the key facts and the writing-style rules.

Verified with a local Jekyll 3.10 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa