### PR TITLE
Remove research panel numbers; add Dr. to lead names

### DIFF
--- a/_includes/research.html
+++ b/_includes/research.html
@@ -7,9 +7,6 @@
 <div class="research-grid">
 
   <article class="research-card">
-    <div class="research-card-head">
-      <span class="research-index">01</span>
-    </div>
     <img class="research-logo" src="{{ '/images/edsim.png' | relative_url }}" alt="ED Sim emergency department floor plan">
     <h3 class="research-title">Multi-Agent AI for Emergency Department Operations</h3>
     <p>
@@ -21,9 +18,6 @@
   </article>
 
   <article class="research-card">
-    <div class="research-card-head">
-      <span class="research-index">02</span>
-    </div>
     <img class="research-logo" src="{{ '/images/starfish-logo.png' | relative_url }}" alt="The STARFISH Project">
     <h3 class="research-title">Secure, Transactable, Agentic Health Data Sharing</h3>
     <p>
@@ -36,9 +30,6 @@
   </article>
 
   <article class="research-card">
-    <div class="research-card-head">
-      <span class="research-index">03</span>
-    </div>
     <img class="research-logo research-logo--contain" src="{{ '/images/agent-evac-logo.png' | relative_url }}" alt="AgentEvac">
     <h3 class="research-title">Agentic Simulation for Wildfire Evacuations</h3>
     <p>
@@ -51,9 +42,6 @@
   </article>
 
   <article class="research-card">
-    <div class="research-card-head">
-      <span class="research-index">04</span>
-    </div>
     <img class="research-logo" src="{{ '/images/lens-logo.png' | relative_url }}" alt="LENS">
     <h3 class="research-title">Role-Aware Multi-Agent Grading of Clinical Summaries</h3>
     <p>
@@ -65,9 +53,6 @@
   </article>
 
   <article class="research-card">
-    <div class="research-card-head">
-      <span class="research-index">05</span>
-    </div>
     <h3 class="research-title">Federated Learning for Edge Service Orchestration</h3>
     <p>
       As <strong>federated learning (FL)</strong> spreads across heterogeneous infrastructures,

--- a/_team/steve-drew.md
+++ b/_team/steve-drew.md
@@ -1,6 +1,6 @@
 ---
 layout: team-member
-name: Steve Drew
+name: Dr. Steve Drew
 last_name: Drew
 title: Lab Director · Assistant Professor, Department of Electrical and Software Engineering, University of Calgary
 picture: /images/profile/drew-steve.jpg

--- a/_team/vincent-michalski.md
+++ b/_team/vincent-michalski.md
@@ -1,6 +1,6 @@
 ---
 layout: team-member
-name: Vincent Michalski
+name: Dr. Vincent Michalski
 last_name: Michalski
 title: Postdoctoral Researcher, University of Calgary
 picture: /images/profile/vincent-michalski.jpg
@@ -8,7 +8,7 @@ email: vincent.michalski@ucalgary.ca
 category: 5
 ---
 
-Vincent Michalski is a postdoctoral researcher in the DENOS Lab, working on representation learning and reasoning.
+Dr. Vincent Michalski is a postdoctoral researcher in the DENOS Lab, working on representation learning and reasoning.
 <br/>
 <br/>
 Find Vincent on [Google Scholar](https://scholar.google.com/citations?user=9BGzHdUAAAAJ).


### PR DESCRIPTION
## Summary
- **Removes the 01–05 index numbers** from the research panels. Each card now starts directly with its logo (or title for the last panel).
- **Adds the "Dr." honorific** to the Director and Postdoc name headings: "Dr. Steve Drew" and "Dr. Vincent Michalski" (and Vincent's bio first mention, to match Steve's).

Verified with a local Jekyll 3.10 build: five panels render without numbers, both lead cards show "Dr."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa