### PR TITLE
Remove all emails

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,6 @@
     </div>
     <div class="footer-col">
       <p class="footer-head">Contact</p>
-      <a href="mailto:steve.drew@ucalgary.ca">steve.drew@ucalgary.ca</a>
       <span>ICT 253, University of Calgary</span>
       <span>2500 University Dr NW, Calgary, AB</span>
     </div>

--- a/_layouts/team-member.html
+++ b/_layouts/team-member.html
@@ -2,7 +2,7 @@
 <article class="member-card member-card--lead">
   <img class="member-photo" src="{{ page.picture | relative_url }}" alt="{{ page.name }}">
   <div class="member-info">
-    <h3 class="member-name"><a href="mailto:{{ page.email }}">{{ page.name }}</a></h3>
+    <h3 class="member-name">{{ page.name }}</h3>
     <p class="member-role">{{ page.title }}</p>
     <div class="member-bio">{{ content }}</div>
   </div>
@@ -11,7 +11,7 @@
 <article class="member-card">
   <img class="member-photo" src="{{ page.picture | relative_url }}" alt="{{ page.name }}">
   <div class="member-info">
-    <h3 class="member-name"><a href="mailto:{{ page.email }}">{{ page.name }}</a></h3>
+    <h3 class="member-name">{{ page.name }}</h3>
     <p class="member-role">{{ page.title }}</p>
     <div class="member-tags">{{ content }}</div>
   </div>

--- a/_layouts/team-nonmember.html
+++ b/_layouts/team-nonmember.html
@@ -1,7 +1,7 @@
 <article class="member-card">
   <img class="member-photo" src="{{ page.picture | relative_url }}" alt="{{ page.name }}">
   <div class="member-info">
-    <h3 class="member-name"><a href="mailto:{{ page.email }}">{{ page.name }}</a></h3>
+    <h3 class="member-name">{{ page.name }}</h3>
     <p class="member-role">{{ page.title }}</p>
     <div class="member-tags">{{ content }}</div>
   </div>

--- a/_team/Guojun-Tang.md
+++ b/_team/Guojun-Tang.md
@@ -4,7 +4,6 @@ name: Guojun Tang
 last_name: Tang
 title: PhD Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Guojun-Tang.jpg
-email: guojun.tang@ucalgary.ca
 category: 1
 ---
 

--- a/_team/Zirui-Wang.md
+++ b/_team/Zirui-Wang.md
@@ -4,7 +4,6 @@ name: Zirui Wang
 last_name: Wang
 title: Master Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Zirui-Wang.jpg
-email: zirui.wang@ucalgary.ca
 category: 2
 ---
 

--- a/_team/alex-burn.md
+++ b/_team/alex-burn.md
@@ -4,7 +4,6 @@ name: Alexander Burn
 last_name: Burn
 title: Master Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/alex-burn.jpeg
-email: alexander.burn@ucalgary.ca
 category: 2
 ---
 

--- a/_team/ali-abbasi.md
+++ b/_team/ali-abbasi.md
@@ -4,7 +4,6 @@ name: Ali Abbasi
 last_name: Abbasi
 title: Master Student 2022 - 2024. currently Ph.D. student at University of South California.
 picture: /images/profile/ali-abbasi.jpeg
-email: ali.abbas1@ucalgary.ca
 category: 8
 ---
 

--- a/_team/bart-maciszewski.md
+++ b/_team/bart-maciszewski.md
@@ -4,7 +4,6 @@ name: Bart Maciszewski
 last_name: Maciszewski
 title: PhD Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/bart-maciszewski.jpg
-email: bart.maciszewski@ucalgary.ca
 category: 1
 ---
 

--- a/_team/fan-dong.md
+++ b/_team/fan-dong.md
@@ -4,7 +4,6 @@ name: Fan Dong
 last_name: Dong
 title: Master Student 2022 - 2024.
 picture: /images/profile/fan-dong.jpg
-email: fan.dong@ucalgary.ca
 category: 8
 ---
 

--- a/_team/farhan-abbas.md
+++ b/_team/farhan-abbas.md
@@ -4,6 +4,5 @@ name: Farhan Abbas
 last_name: Abbas
 title: Undergraduate Intern, University of Calgary
 picture: /images/profile/farhan-abbas.jpg
-email: farhan.abbas@ucalgary.ca
 category: 4
 ---

--- a/_team/hossein.md
+++ b/_team/hossein.md
@@ -4,7 +4,6 @@ name: Hossein KhademSohi
 last_name: KhademSohi
 title: PhD Candidate in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Hossein.jpeg
-email: hossein.khademsohi@ucalgary.ca
 category: 1
 ---
 

--- a/_team/hutton-ledingham.md
+++ b/_team/hutton-ledingham.md
@@ -4,7 +4,6 @@ name: Hutton Ledingham
 last_name: Ledingham
 title: Summer Intern at 2025.
 picture: /images/profile/hutton-ledingham.jpeg
-email: hutton.ledingham@ucalgary.ca
 category: 4
 ---
 

--- a/_team/jiajun-wu.md
+++ b/_team/jiajun-wu.md
@@ -4,7 +4,6 @@ name: Jiajun Wu
 last_name: Wu
 title: PhD Candidate in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Jiajun-Wu.jpg
-email: jiajun.wu1@ucalgary.ca
 category: 1
 ---
 

--- a/_team/jialin-yang.md
+++ b/_team/jialin-yang.md
@@ -4,7 +4,6 @@ name: Jialin Yang
 last_name: Yang
 title: PhD Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Jialin-Yang.jpg
-email: jialin.yang@ucalgary.ca
 category: 1
 ---
 

--- a/_team/leo-wei.md
+++ b/_team/leo-wei.md
@@ -4,7 +4,6 @@ name: Leo Wei
 last_name: Wei
 title: Master Student 2023 - 2025. First employment as Lead Software Engineer at Broadbill Energy Inc.
 picture: /images/profile/leo-wei.jpeg
-email: hanzhe.wei@ucalgary.ca
 category: 8
 ---
 

--- a/_team/steve-drew.md
+++ b/_team/steve-drew.md
@@ -4,7 +4,6 @@ name: Dr. Steve Drew
 last_name: Drew
 title: Lab Director · Assistant Professor, Department of Electrical and Software Engineering, University of Calgary
 picture: /images/profile/drew-steve.jpg
-email: steve.drew@ucalgary.ca
 category: 0
 ---
 

--- a/_team/swaleh-zaidi.md
+++ b/_team/swaleh-zaidi.md
@@ -4,7 +4,6 @@ name: Swaleh Zaidi
 last_name: Zaidi
 title: Summer Intern at 2025.
 picture: /images/profile/swaleh-zaidi.jpeg
-email: swaleh.zaidi@ucalgary.ca
 category: 4
 ---
 

--- a/_team/vincent-michalski.md
+++ b/_team/vincent-michalski.md
@@ -4,7 +4,6 @@ name: Dr. Vincent Michalski
 last_name: Michalski
 title: Postdoctoral Researcher, University of Calgary
 picture: /images/profile/vincent-michalski.jpg
-email: vincent.michalski@ucalgary.ca
 category: 5
 ---
 

--- a/_team/yunkai-bao.md
+++ b/_team/yunkai-bao.md
@@ -4,7 +4,6 @@ name: Yunkai Bao
 last_name: Bao
 title: PhD Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/Yunkai-Bao.jpg
-email: yunkai.bao@ucalgary.ca
 category: 1
 ---
 

--- a/_team/zainab-saad.md
+++ b/_team/zainab-saad.md
@@ -4,7 +4,6 @@ name: Zainab Saad
 last_name: Saad
 title: Master Student in Electrical and Software Engineering, University of Calgary
 picture: /images/profile/zainab-saad.jpeg
-email: zainab.saad1@ucalgary.ca
 category: 2
 ---
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -450,9 +450,7 @@ strong, b { font-weight: 600; }
   margin-bottom: 1.4rem;
   background: var(--surface-2);
 }
-.member-name { font-size: 1.7rem; font-weight: 700; line-height: 1.2; margin: 0 0 .4rem; }
-.member-name a { color: var(--navy-900); }
-.member-name a:hover { color: var(--gold-deep); }
+.member-name { font-size: 1.7rem; font-weight: 700; line-height: 1.2; margin: 0 0 .4rem; color: var(--navy-900); }
 .member-role { font-size: 1.35rem; line-height: 1.45; color: var(--muted); margin: 0; }
 .member-tags { font-size: 1.3rem; line-height: 1.5; color: var(--muted-soft); margin-top: 1rem; }
 .member-tags br:first-child { display: none; }


### PR DESCRIPTION
Removes all email addresses from the site and source:
- The `mailto:` links behind team-member names (names are now plain text).
- The contact email in the footer (kept the office + mailing address).
- The `email:` field from every team member's front matter, since the repo is public and those addresses are otherwise exposed in the source.

Member names now render as plain navy text. Verified with a local Jekyll 3.10 build: no `mailto`, `@ucalgary`, or `@gmail` anywhere in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa