### PR TITLE
Add IGDM Lab as a partner

### DIFF
--- a/_includes/partnerships.html
+++ b/_includes/partnerships.html
@@ -9,4 +9,8 @@
   <a class="partner-card" href="https://illidanlab.github.io/" target="_blank" rel="noopener" title="Intelligent Data Analytics (ILLIDAN) Lab, University of Michigan">
     <img class="partner-logo" src="{{ '/images/illidan-logo.png' | relative_url }}" alt="Intelligent Data Analytics (ILLIDAN) Lab, University of Michigan">
   </a>
+  <a class="partner-card partner-card--text" href="https://researchdirectory.ucalgary.ca/intelligent-geospatial-data-mining" target="_blank" rel="noopener" title="Intelligent Geospatial Data Mining Lab, University of Calgary">
+    <span class="partner-name">Intelligent Geospatial Data Mining Lab</span>
+    <span class="partner-sub">University of Calgary</span>
+  </a>
 </div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -553,6 +553,22 @@ strong, b { font-weight: 600; }
 }
 .partner-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: #d6deea; }
 .partner-logo { max-width: 100%; max-height: 60px; width: auto; height: auto; display: block; }
+.partner-card--text { flex-direction: column; gap: .6rem; text-align: center; }
+.partner-name {
+  font-family: var(--font-serif);
+  font-size: 1.9rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--navy-900);
+}
+.partner-sub {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+.partner-card:hover .partner-name { color: var(--gold-deep); }
 
 /* Footer ------------------------------------------------------------------ */
 .site-footer { background: var(--navy-900); color: #b9c4d8; }


### PR DESCRIPTION
Adds the **Intelligent Geospatial Data Mining (IGDM) Lab** at the University of Calgary as a third partner, linking to https://researchdirectory.ucalgary.ca/intelligent-geospatial-data-mining.

It has no logo (the directory page only carries the generic UCalgary mark), so it uses a new **text-based** partner card (`.partner-card--text`) showing the lab name in serif with a "University of Calgary" subtitle, sized to match the TAIH and ILLIDAN logo cards.

Verified with a local Jekyll 3.10 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa