### PR TITLE
Link alumni names to their LinkedIn pages

### DIFF
--- a/_team/ali-abbasi.md
+++ b/_team/ali-abbasi.md
@@ -5,6 +5,7 @@ last_name: Abbasi
 title: Master Student 2022 - 2024. currently Ph.D. student at University of South California.
 picture: /images/profile/ali-abbasi.jpeg
 category: 8
+link: https://www.linkedin.com/in/ali-abbasi-a968b315b/
 ---
 
 <br/>

--- a/_team/axel-sanchez.md
+++ b/_team/axel-sanchez.md
@@ -5,4 +5,5 @@ last_name: Sanchez
 title: Undergraduate Intern, University of Calgary
 picture: /images/profile/axel-sanchez.jpg
 category: 8
+link: https://www.linkedin.com/in/axel-sanchez-a1089b23a/
 ---

--- a/_team/fan-dong.md
+++ b/_team/fan-dong.md
@@ -5,6 +5,7 @@ last_name: Dong
 title: Master Student 2022 - 2024.
 picture: /images/profile/fan-dong.jpg
 category: 8
+link: https://www.linkedin.com/in/fan-dong-1203b9147/
 ---
 
 <br/>

--- a/_team/leo-wei.md
+++ b/_team/leo-wei.md
@@ -5,6 +5,7 @@ last_name: Wei
 title: Master Student 2023 - 2025. First employment as Lead Software Engineer at Broadbill Energy Inc.
 picture: /images/profile/leo-wei.jpeg
 category: 8
+link: https://www.linkedin.com/in/leo-wei/
 ---
 
 <br/>


### PR DESCRIPTION
Adds a `link:` field to each alum pointing to their LinkedIn profile, so their name becomes a clickable link (new tab) via the existing mechanism:
- Ali Abbasi, Fan Dong, Axel Sanchez, Leo Wei.

Verified with a local Jekyll 3.10 build (4 LinkedIn name links rendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa