### PR TITLE
Remove Calendar and Software from the nav menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,8 +61,6 @@
           <li class="navbar-item"><a class="navbar-link" href="#team">Team</a></li>
           <li class="navbar-item"><a class="navbar-link" href="#partnerships">Partnerships</a></li>
           <li class="navbar-item"><a class="navbar-link" href="#publications">Publications</a></li>
-          <li class="navbar-item"><a class="navbar-link" href="#calendar">Calendar</a></li>
-          <li class="navbar-item"><a class="navbar-link" href="https://github.com/DENOSlab/" target="_blank" rel="noopener">Software</a></li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
Removes the **Calendar** and **Software** items from the navbar. Nav is now About, Research, News, Team, Partnerships, Publications. The Calendar section remains on the page (unlinked); say the word to remove the section too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa