### PR TITLE
Scale the site logo to 80%

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -141,7 +141,7 @@ strong, b { font-weight: 600; }
 }
 .hero-logo {
   width: 100%;
-  max-width: 460px;
+  max-width: 368px;
   height: auto;
   margin: 0 0 2.6rem;
   display: block;
@@ -166,7 +166,7 @@ strong, b { font-weight: 600; }
   padding-top: 1.8rem;
   padding-bottom: 1.8rem;
 }
-.subheader-brand img { height: 4.6rem; width: auto; display: block; }
+.subheader-brand img { height: 3.68rem; width: auto; display: block; }
 .subheader-back { font-size: 1.4rem; font-weight: 600; color: var(--navy); white-space: nowrap; }
 .subheader-back:hover { color: var(--gold-deep); }
 


### PR DESCRIPTION
Reduces the hero logo (460px to 368px max-width) and the sub-page header logo (4.6rem to 3.68rem) to 80% of their previous size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa