### PR TITLE
Enlarge the CEMDL partner logo to match TAIH

### DIFF
--- a/_includes/partnerships.html
+++ b/_includes/partnerships.html
@@ -4,7 +4,7 @@
 
 <div class="partner-grid">
   <a class="partner-card" href="https://www.linkedin.com/company/calgary-emergency-medicine-data-lab/" target="_blank" rel="noopener" title="Calgary Emergency Medicine Data Lab (CEMDL)">
-    <img class="partner-logo" src="{{ '/images/CEMDL-logo.png' | relative_url }}" alt="Calgary Emergency Medicine Data Lab (CEMDL)">
+    <img class="partner-logo partner-logo--tall" src="{{ '/images/CEMDL-logo.png' | relative_url }}" alt="Calgary Emergency Medicine Data Lab (CEMDL)">
   </a>
   <a class="partner-card" href="https://taih.ca" target="_blank" rel="noopener" title="Transdisciplinary Artificial Intelligence Hub">
     <img class="partner-logo" src="{{ '/images/taih-transparentbg.png' | relative_url }}" alt="Transdisciplinary Artificial Intelligence Hub (TAIH)">

--- a/css/custom.css
+++ b/css/custom.css
@@ -555,6 +555,7 @@ strong, b { font-weight: 600; }
 }
 .partner-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: #d6deea; }
 .partner-logo { max-width: 100%; max-height: 60px; width: auto; height: auto; display: block; }
+.partner-logo--tall { max-height: 100px; }
 .partner-card--text { flex-direction: column; gap: .6rem; text-align: center; }
 .partner-name {
   font-family: var(--font-serif);


### PR DESCRIPTION
The CEMDL logo looked small next to TAIH because it is a compact (2.46:1) lockup: at the shared 60px max-height it rendered 148px wide vs TAIH's 256px. Added a `.partner-logo--tall` (100px max-height) for it so its width now matches TAIH (~246px). Other logos are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5X5kGFJXGLmT29xpNyqCa