### PR TITLE
Align About and Research intros to full width and justify them

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -83,6 +83,7 @@ strong, b { font-weight: 600; }
   max-width: 68ch;
   margin: 0 0 3.2rem;
 }
+#research .section-lead { max-width: none; text-align: justify; }
 .subhead {
   font-family: var(--font-sans);
   font-size: 1.3rem;
@@ -236,7 +237,7 @@ strong, b { font-weight: 600; }
 .popover-link:hover { background: var(--surface); color: var(--navy-900); }
 
 /* About copy -------------------------------------------------------------- */
-.copy { max-width: 74ch; }
+.copy { text-align: justify; }
 .copy p { font-size: 1.85rem; line-height: 1.7; color: #2c3543; margin: 0 0 1.8rem; }
 .copy p:last-child { margin-bottom: 0; }
 .copy strong { color: var(--navy-900); font-weight: 600; }


### PR DESCRIPTION
## What

The **About the lab** copy and the **Research** lead paragraph were capped at a narrow measure (`74ch` / `68ch`), so their right edge stopped short of the full-width block directly beneath them — the blue *Join the lab* callout and the research grid. This made the section intros look misaligned with their own content.

- Drop the width cap on `.copy` (About-only) so it fills the wrap width and lines up with the blue callout, and **justify** it.
- Scope a `#research .section-lead` override to drop the cap and justify the Research lead, matching the research grid width.

The Research override is scoped to `#research` so the shared `.section-lead` used on `/news/`, Partnerships, Publications, and Calendar is left unchanged.

## Verification

Built locally against **Jekyll 3.10** and screenshotted: the About text now aligns flush with the blue box, the Research lead matches the grid width, and both read as justified. No change to other sections or the `/news/` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)